### PR TITLE
サインイン、サインアウト機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+def after_sign_out_path_for(resource)
+  '/users/sign_in'
+end
+
 def configure_permitted_parameters
   devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
 end


### PR DESCRIPTION
#what
application_controllerにサインアウト後のパスを設定

#why
サインイン、サインアウト機能実装のため