### PR TITLE
show_users_group

### DIFF
--- a/app/assets/stylesheets/_chat_box.scss
+++ b/app/assets/stylesheets/_chat_box.scss
@@ -10,27 +10,33 @@
     border-color: #eeeeee;
     padding: 0 40px 0 40px;
     border-width: thin;
+    height: 100px;
+  &_left {
+    float: left;
   h1 {
   font-size: 20px;
   color: #333333;
   float: left;
   margin: 35px 0 15px 0;
   }
-  a {
-  float: right;
-  color: blue;
-  background-color: $white-color;
-  border-color: $sky-color;
-  margin:28px 0 0 0;
-  padding:0 20px;
-  line-height: 40px;
-  border-width: thin;
-  text-decoration: none;
-  }
-  h3 {
+  h2 {
   color: #999999;
   font-size: 12px;
   clear: both;
+  }
+  }
+  &_right {
+  border: 1px solid #38AEF0;
+  color: #38AEF0;
+  float: right;
+  height: 40px;
+  line-height: 40px;
+  margin-top: 28px;
+  padding: 0 20px;
+    a {
+  color: #38AEF0;
+  text-decoration: none;
+  }
   }
   }
   

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
 
-def index
-end
+  def index
+    @groups = current_user.groups
+  end
 
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -16,9 +16,11 @@
           %p まだメッセージはありません。
   .chat_box
     .chat_box__upper
-      %h1 テスト
-      %a{href: "/groups/#{current_user.id}/edit"} Edit
-      %h3 member:test
+      .chat_box__upper_left
+        %h1 @group.name
+        %h2 member:test
+      .chat_box__upper_right
+        %a{href: "/groups/1/edit"} Edit
     .chat_box__middle
       .chat_box__middle_message
         %h1 テスト

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -9,19 +9,15 @@
         = link_to new_group_path do
           %i.fa.fa-pencil-square-o
     .group_box__middle_list
-      .group_box__middle_list_name
-        %h1 aaaaaaaaaaaaaa
-        %p まだメッセージはありません。
-      .group_box__middle_list_name
-        %h1 テスト
-        %p まだメッセージはありません。
-      .group_box__middle_list_name
-        %h1 テスト
-        %p まだメッセージはありません。
+      -@groups.each do |group|
+        .group_box__middle_list_name
+          %h1
+          =group.name
+          %p まだメッセージはありません。
   .chat_box
     .chat_box__upper
       %h1 テスト
-      %a{href: "/groups/:id/edit"} Edit
+      %a{href: "/groups/#{current_user.id}/edit"} Edit
       %h3 member:test
     .chat_box__middle
       .chat_box__middle_message


### PR DESCRIPTION
#what ビュー、コントローラーの編集
#why ユーザーの所属グループをサイドバーに表示するため